### PR TITLE
Uso de llaves para bloques que encadenan.

### DIFF
--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -37,3 +37,7 @@ Style/MutableConstant:
 # https://rubocop.readthedocs.io/en/latest/cops_style/#styleregexpliteral
 Style/RegexpLiteral:
   Enabled: false
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/#styleblockdelimiters
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining


### PR DESCRIPTION
Pendiente de hacer votación en canal desarrolladores:

[https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters)

Mirar el apartado `EnforcedStyle: braces_for_chaining`

