### PR TITLE
Remove Style/BracesAroundHashParameters cop

### DIFF
--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -6,10 +6,6 @@
 Style/AsciiComments:
   Enabled: false
 
-# https://rubocop.readthedocs.io/en/latest/cops_style/#stylebracesaroundhashparameters
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
-
 # https://rubocop.readthedocs.io/en/latest/cops_style/#styledatetime
 Style/DateTime:
   Enabled: false


### PR DESCRIPTION
This cop is not necessary due to this:

- https://github.com/rubocop-hq/rubocop/issues/7641
- https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/