### PR TITLE
Updated cops to rubocop 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2020-11-04
+### Added
+- Added new rules introduced in the last version.
+    - Lint/DuplicateRegexpCharacterClassElement (1.1)
+    - Lint/EmptyBlock (1.1)
+    - Lint/ToEnumArguments (1.1)
+    - Lint/UnmodifiedReduceAccumulator (1.1)
+    - Style/ArgumentsForwarding (1.1)
+    - Style/DocumentDynamicEvalDefinition (1.1)
+    - Style/SwapValues (1.1)
+- Added new rules introduced in the last version of rubocop-rspec
+    - RSpec/Rails/HttpStatus (2.pre)
+
+### Changed
+- Removed shared enabled rules with rubocop 1.0
+- Bump dependencies (rubocop 1.0 and rubocop-rspec 2.pre)
+- Bump ruby version to use `...`
+- Reordered some rules following the convention of namespace/file.
+
+
 ## 0.10.0 - 2020-11-04
 ### Added
 - Added new rules introduced in the last version.

--- a/rubocop-layout.yml
+++ b/rubocop-layout.yml
@@ -2,14 +2,6 @@
 ## https://rubocop.readthedocs.io/en/latest/cops_layout/
 #
 
-# https://docs.rubocop.org/en/stable/cops_layout/#layoutemptylinesaroundattributeaccessor
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-# https://docs.rubocop.org/en/stable/cops_layout/#layoutspacearoundmethodcalloperator
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 # https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutfirstarrayelementindentation
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
@@ -29,7 +21,3 @@ Layout/SpaceAroundEqualsInParameterDefault:
 # https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutspaceinsidehashliteralbraces
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-
-# https://docs.rubocop.org/rubocop/cops_layout.html#layoutbeginendalignment
-Layout/BeginEndAlignment:
-  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -2,88 +2,22 @@
 ## https://rubocop.readthedocs.io/en/latest/cops_lint/
 #
 
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintraiseexception
-Lint/RaiseException:
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicateregexpcharacterclasselement
+Lint/DuplicateRegexpCharacterClassElement:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintstructnewoverride
-Lint/StructNewOverride:
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyblock
+Lint/EmptyBlock:
+  Enabled: true
+  Exclude:
+    - "**/spec/factories/**/*.rb"
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#linttoenumarguments
+Lint/ToEnumArguments:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintdeprecatedopensslconstant
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintmixedregexpcapturetypes
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicateelsifcondition
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintbinaryoperatorwithidenticaloperands
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicaterescueexception
-Lint/DuplicateRescueException:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyconditionalbody
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintfloatcomparison
-Lint/FloatComparison:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintoutofrangeregexpref
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintselfassignment
-Lint/SelfAssignment:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#linttoplevelreturnwithargument
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintunreachableloop
-Lint/UnreachableLoop:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintmissingsuper
-Lint/MissingSuper:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintconstantdefinitioninblock
-Lint/ConstantDefinitionInBlock:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicaterequire
-Lint/DuplicateRequire:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyfile
-Lint/EmptyFile:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintidentitycomparison
-Lint/IdentityComparison:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#linttrailingcommainattributedeclaration
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessmethoddefinition
-Lint/UselessMethodDefinition:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintuselesstimes
-Lint/UselessTimes:
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintunmodifiedreduceaccumulator
+Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 
 # https://docs.rubocop.org/rubocop/cops_lint.html#linthashcomparebyidentity

--- a/rubocop-metrics.yml
+++ b/rubocop-metrics.yml
@@ -13,3 +13,17 @@ Metrics/ClassLength:
 # https://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsmethodlength
 Metrics/MethodLength:
   Enabled: false
+
+# https://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsmodulelength
+Metrics/ModuleLength:
+  Exclude:
+    - "**/config/routes.rb"
+    - "**/spec/**/*.rb"
+
+# https://rubocop.readthedocs.io/en/latest/cops_metrics/#blocklength
+Metrics/BlockLength:
+  Exclude:
+    - "**/spec/**/*.rb"
+    - "**/config/environments/*.rb"
+    - "**/config/routes.rb"
+    - "**/lib/tasks/auto_annotate_models.rake"

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '0.10.0'
+  s.version = '1.0.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.0'
+  s.add_dependency 'rubocop', '~> 1.1'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.8'
   s.add_dependency 'rubocop-rails', '~> 2.8'

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -42,15 +42,15 @@ Gem::Specification.new do |s|
   ## REQUIREMENTS
   #
   s.platform              = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 0.93'
+  s.add_dependency 'rubocop', '~> 1.0'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.8'
   s.add_dependency 'rubocop-rails', '~> 2.8'
   s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 1.44'
+  s.add_dependency 'rubocop-rspec', '~> 2.pre'
 end

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -38,16 +38,10 @@ RSpec/MultipleExpectations:
 RSpec/NestedGroups:
   Max: 5
 
-# https://rubocop.readthedocs.io/en/latest/cops_style/#styleblockcomments
-Style/BlockComments:
-  Exclude:
-    - "**/spec/**/*.rb"
-
-# https://rubocop.readthedocs.io/en/latest/cops_style/#styleblockdelimiters
-Style/BlockDelimiters:
-  Exclude:
-    - "**/spec/**/*.rb"
-
-# https://rubocop.readthedocs.io/en/latest/cops_style/#rspecstubbedmock
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecstubbedmock
 RSpec/StubbedMock:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rails.html#railshttpstatus
+RSpec/Rails/HttpStatus:
+  EnforcedStyle: numeric

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -9,119 +9,42 @@ Style/AsciiComments:
 # https://rubocop.readthedocs.io/en/latest/cops_style/#styleblockdelimiters
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+  Exclude:
+    - "**/spec/**/*.rb"
 
 # https://docs.rubocop.org/rubocop/cops_style.html#styledocumentation
 Style/Documentation:
   Enabled: false
 
-# https://docs.rubocop.org/rubocop/cops_style.html#styleexponentialnotation
-Style/ExponentialNotation:
-  Enabled: true
-
 # https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcommetn
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylehasheachmethods
-Style/HashEachMethods:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylehashtransformkeys
-Style/HashTransformKeys:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylehashtransformvalues
-Style/HashTransformValues:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleregexpliteral
-Style/RegexpLiteral:
-  AllowInnerSlashes: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleslicingwithrange
-Style/SlicingWithRange:
-  Enabled: true
 
 # https://docs.rubocop.org/rubocop/cops_style.html#styleaccessorgrouping
 Style/AccessorGrouping:
   Enabled: false
 
-# https://docs.rubocop.org/rubocop/cops_style.html#stylebisectedattraccessor
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantassignment
-Style/RedundantAssignment:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantfetchblock
-Style/RedundantFetchBlock:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpcharacterclass
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpescape
-Style/RedundantRegexpEscape:
-  Enabled: true
-
 # https://docs.rubocop.org/rubocop/cops_style.html#stylearraycoercion
 Style/ArrayCoercion:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#stylecaselikeif
-Style/CaseLikeIf:
+# https://docs.rubocop.org/rubocop/cops_style.html#styleargumentsforwarding
+Style/ArgumentsForwarding:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem
-Style/HashAsLastArrayItem:
+# https://docs.rubocop.org/rubocop/cops_style.html#styledocumentdynamicevaldefinition
+Style/DocumentDynamicEvalDefinition:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#stylehashlikecase
-Style/HashLikeCase:
+# https://docs.rubocop.org/rubocop/cops_style.html#styleswapvalues
+Style/SwapValues:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantfileextensioninrequire
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
+# https://rubocop.readthedocs.io/en/latest/cops_style/#styleblockcomments
+Style/BlockComments:
+  Exclude:
+    - "**/spec/**/*.rb"
 
-# https://docs.rubocop.org/rubocop/cops_style.html#styleexplicitblockargument
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleglobalstdstream
-Style/GlobalStdStream:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleoptionalbooleanparameter
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylesingleargumentdig
-Style/SingleArgumentDig:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylestringconcatenation
-Style/StringConcatenation:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylecombinableloops
-Style/CombinableLoops:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylekeywordparametersorder
-Style/KeywordParametersOrder:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantselfassignment
-Style/RedundantSelfAssignment:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#stylesolenestedconditional
-Style/SoleNestedConditional:
-  Enabled: true
-
-# https://docs.rubocop.org/rubocop/cops_style.html#styleclassequalitycomparison
-Style/ClassEqualityComparison:
-  Enabled: true
+# https://docs.rubocop.org/rubocop/cops_style.html#styleregexpliteral
+Style/RegexpLiteral:
+  AllowInnerSlashes: true


### PR DESCRIPTION
The following PR introduces:

- Enabled rules by default have been removed from our configuration. 
- New rules from 1.0 have been configured. 
- Dependencies have also been updated
- Ruby has been updated to include rule of using `...`