### PR TITLE
Feature/new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 - 2020-12-15
+### Added
+- Added new rules introduced in the last version.
+    - rubocop
+      - Lint/UnexpectedBlockArity (1.5)
+    - rubocop-rails
+      - Rails/AttributeDefaultBlockValue (2.9)
+      - Rails/WhereEquals (2.9)
+
 ## 1.3.0 - 2020-11-25
 ### Added
 - Added new rules introduced in the last version.

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -39,3 +39,7 @@ Lint/DuplicateBranch:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyclass
 Lint/EmptyClass:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintunexpectedblockarity
+Lint/UnexpectedBlockArity:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -47,10 +47,10 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.4'
+  s.add_dependency 'rubocop', '~> 1.6'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.9'
-  s.add_dependency 'rubocop-rails', '~> 2.8'
+  s.add_dependency 'rubocop-rails', '~> 2.9'
   s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 2.pre'
+  s.add_dependency 'rubocop-rspec', '~> 2.0'
 end

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.3.0'
+  s.version = '1.4.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -109,3 +109,11 @@ Rails/SquishedSQLHeredocs:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswherenot
 Rails/WhereNot:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsattributedefaultblockvalue
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswhereequals
+Rails/WhereEquals:
+  Enabled: true


### PR DESCRIPTION
Added new rules introduced in the last version.
    - rubocop
      - Lint/UnexpectedBlockArity (1.5)
    - rubocop-rails
      - Rails/AttributeDefaultBlockValue (2.9)
      - Rails/WhereEquals (2.9)

Rubocop version has been bumped to 1.6 and rubocop-rails to 2.9. rubocop-rspec has also been changed from pre version to stable