### PR TITLE
Feature/new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+The following rules have been added:
+
+## 1.5.0 - 2021-02-25
+
+### Added
+- Added new rules introduced in the last version.
+  -rubocop
+    - Gemspec/DateAssignment (1.10)
+    - Layout/SpaceBeforeBrackets (1.7)
+    - Lint/AmbiguousAssignment (1.7)
+    - Lint/DeprecatedConstants (1.8)
+    - Lint/LambdaWithoutLiteralBlock (1.8)
+    - Lint/NumberedParameterAssignment (1.9)
+    - Lint/OrAssignmentToConstant (1.9)
+    - Lint/RedundantDirGlobSort (1.8)
+    - Lint/SymbolConversion (1.9)
+    - Lint/TripleQuotes (1.9)
+    - Style/EndlessMethod (1.8)
+    - Style/HashConversion (1.10)
+    - Style/HashExcept (1.7)
+    - Style/IfWithBooleanLiteralBranches (1.9)
+
 ## 1.4.0 - 2020-12-15
 ### Added
 - Added new rules introduced in the last version.

--- a/rubocop-gemspec.yml
+++ b/rubocop-gemspec.yml
@@ -1,3 +1,7 @@
 #
 ## https://rubocop.readthedocs.io/en/latest/cops_gemspec/
 #
+
+# https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdateassignment
+Gemspec/DateAssignment:
+  Enabled: true

--- a/rubocop-layout.yml
+++ b/rubocop-layout.yml
@@ -21,3 +21,7 @@ Layout/SpaceAroundEqualsInParameterDefault:
 # https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutspaceinsidehashliteralbraces
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutspacebeforebrackets
+Layout/SpaceBeforeBrackets:
+  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -43,3 +43,35 @@ Lint/EmptyClass:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintunexpectedblockarity
 Lint/UnexpectedBlockArity:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintambiguousassignment
+Lint/AmbiguousAssignment:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintdeprecatedconstants
+Lint/DeprecatedConstants:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintlambdawithoutliteralblock
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintnumberedparameterassignment
+Lint/NumberedParameterAssignment:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintorassignmenttoconstant
+Lint/OrAssignmentToConstant:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantdirglobsort
+Lint/RedundantDirGlobSort:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintsymbolconversion
+Lint/SymbolConversion:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#linttriplequotes
+Lint/TripleQuotes:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.4.0'
+  s.version = '1.5.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -47,10 +47,10 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.6'
+  s.add_dependency 'rubocop', '~> 1.10'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.9'
   s.add_dependency 'rubocop-rails', '~> 2.9'
   s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 2.0'
+  s.add_dependency 'rubocop-rspec', '~> 2.2'
 end

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -64,3 +64,19 @@ Style/NilLambda:
 # https://docs.rubocop.org/rubocop/cops_style.html#styleredundantargument
 Style/RedundantArgument:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleendlessmethod
+Style/EndlessMethod:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylehashconversion
+Style/HashConversion:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylehashexcept
+Style/HashExcept:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleifwithbooleanliteralbranches
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true


### PR DESCRIPTION
Added new rules introduced in the last version.
  -rubocop
    - Gemspec/DateAssignment (1.10)
    - Layout/SpaceBeforeBrackets (1.7)
    - Lint/AmbiguousAssignment (1.7)
    - Lint/DeprecatedConstants (1.8)
    - Lint/LambdaWithoutLiteralBlock (1.8)
    - Lint/NumberedParameterAssignment (1.9)
    - Lint/OrAssignmentToConstant (1.9)
    - Lint/RedundantDirGlobSort (1.8)
    - Lint/SymbolConversion (1.9)
    - Lint/TripleQuotes (1.9)
    - Style/EndlessMethod (1.8)
    - Style/HashConversion (1.10)
    - Style/HashExcept (1.7)
    - Style/IfWithBooleanLiteralBranches (1.9)