### PR TITLE
Added new rules and upgraded dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The following rules have been added:
 
+## 1.7.0 - 2021-06-29
+- Added new rules introduced in the last version.
+  - rubocop-rails
+    - Rails/AddColumnIndex (2.11)
+    - Rails/ExpandedDateRange (2.11)
+    - Rails/I18nLocaleAssignment (2.11)
+    - Rails/UnusedIgnoredColumns (2.11)
+    - Rails/EagerEvaluationLogMessage (2.11)
+  - rubocop-rspec
+    - RSpec/IdenticalEqualityAssertion (2.4)
+    - RSpec/Rails/AvoidSetupHook (2.4)
+
+### Changed
+- Updated dependency rubocop-rails and rubocop-rspec
+
 ## 1.6.0 - 2021-06-08
 
 ### Added

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.6.0'
+  s.version = '1.7.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rubocop', '~> 1.10'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.9'
-  s.add_dependency 'rubocop-rails', '~> 2.10'
+  s.add_dependency 'rubocop-rails', '~> 2.11'
   s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 2.2'
+  s.add_dependency 'rubocop-rspec', '~> 2.4'
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -125,3 +125,23 @@ Rails/EnvironmentVariableAccess:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstimezoneassignment
 Rails/TimeZoneAssignment:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsaddcolumnindex
+Rails/AddColumnIndex:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexpandeddaterange
+Rails/ExpandedDateRange:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsi18nlocaleassignment
+Rails/I18nLocaleAssignment:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedignoredcolumns
+Rails/UnusedIgnoredColumns:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railseagerevaluationlogmessage
+Rails/EagerEvaluationLogMessage:
+  Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -45,3 +45,11 @@ RSpec/StubbedMock:
 # https://docs.rubocop.org/rubocop-rspec/cops_rails.html#railshttpstatus
 RSpec/Rails/HttpStatus:
   EnforcedStyle: numeric
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec/rails.html#rspecrailsavoidsetuphook
+RSpec/Rails/AvoidSetupHook:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecidenticalequalityassertion
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true


### PR DESCRIPTION
Both rubocop-rails and rubocop-rspec have been upgraded. The following
rules have been added:
- Rails/AddColumnIndex (2.11)
- Rails/ExpandedDateRange (2.11)
- Rails/I18nLocaleAssignment (2.11)
- Rails/UnusedIgnoredColumns (2.11)
- RSpec/IdenticalEqualityAssertion (2.4)
- RSpec/Rails/AvoidSetupHook (2.4)
- Rails/EagerEvaluationLogMessage (2.11)