### PR TITLE
New rules from rubocop 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The following rules have been added:
 
+## 1.8.0 - 2021-06-29
+- Added new rules introduced in the last version.
+  - rubocop
+    - Layout/LineEndStringConcatenationIndentation (1.18)
+    - Naming/InclusiveLanguage (1.18)
+
+### Changed
+- Updated dependency rubocop
+
 ## 1.7.0 - 2021-06-29
 - Added new rules introduced in the last version.
   - rubocop-rails

--- a/rubocop-layout.yml
+++ b/rubocop-layout.yml
@@ -25,3 +25,8 @@ Layout/SpaceInsideHashLiteralBraces:
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutspacebeforebrackets
 Layout/SpaceBeforeBrackets:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutlineendstringconcatenationindentation
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true
+  EnforcedStyle: aligned

--- a/rubocop-naming.yml
+++ b/rubocop-naming.yml
@@ -5,3 +5,7 @@
 # https://docs.rubocop.org/rubocop/cops_naming.html#namingvariablenumber
 Naming/VariableNumber:
   EnforcedStyle: snake_case
+
+# https://docs.rubocop.org/rubocop/cops_naming.html#naminginclusivelanguage
+Naming/InclusiveLanguage:
+  Enabled: false

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.10'
+  s.add_dependency 'rubocop', '~> 1.18'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.9'
   s.add_dependency 'rubocop-rails', '~> 2.11'

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.7.0'
+  s.version = '1.8.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'


### PR DESCRIPTION
Rubocop has been updated to 1.18 and the following rules have been introduced:
  - Layout/LineEndStringConcatenationIndentation (1.18)
  - Naming/InclusiveLanguage (1.18)