### PR TITLE
Ignore routes directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The following rules have been added:
 
+## 1.8.1 - 2021-07-26
+
+### Changed
+- `config/routes/` directory should have the same rules as `config/routes.rb`
+
 ## 1.8.0 - 2021-06-29
 - Added new rules introduced in the last version.
   - rubocop

--- a/rubocop-metrics.yml
+++ b/rubocop-metrics.yml
@@ -18,6 +18,7 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Exclude:
     - "**/config/routes.rb"
+    - "**/config/routes/**/*.rb"
     - "**/spec/**/*.rb"
 
 # https://rubocop.readthedocs.io/en/latest/cops_metrics/#blocklength
@@ -26,4 +27,5 @@ Metrics/BlockLength:
     - "**/spec/**/*.rb"
     - "**/config/environments/*.rb"
     - "**/config/routes.rb"
+    - "**/config/routes/**/*.rb"
     - "**/lib/tasks/auto_annotate_models.rake"

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.8.0'
+  s.version = '1.8.1'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'


### PR DESCRIPTION
`routes` directory should have the same rules as routes.rb, so both
BlockLength and ModuleLength have been disabled for this directory