### PR TITLE
Added new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The following rules have been added:
 
+## 1.11.0 - 2021-09-28
+- Added new rules
+  - rubocop
+    - Lint/AmbiguousOperatorPrecedence (1.21)
+    - Lint/IncompatibleIoSelectWithFiberScheduler (1.21)
+  - rubocop-rails
+    - Rails/RedundantTravelBack (2.12)
+  - rubocop-rspec
+    - RSpec/ExcessiveDocstringSpacing (2.5)
+    - RSpec/SubjectDeclaration (2.5)
+
+### Changed
+- Updated dependency rubocop to 1.21
+- Updated dependency rubocop-rails to 2.12
+- Updated dependency rubocop-rspec to 2.5
+
 ## 1.10.0 - 2021-08-25
 ### Changed
 - Layout/SpaceAroundEqualsInParameterDefault has been changed to the default value (aka space)

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -83,3 +83,11 @@ Lint/EmptyInPattern:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintambiguousrange
 Lint/AmbiguousRange:
   Enabled: false
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintambiguousoperatorprecedence
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintincompatibleioselectwithfiberscheduler
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.10.0'
+  s.version = '1.11.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -47,10 +47,10 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.19'
+  s.add_dependency 'rubocop', '~> 1.21'
   s.add_dependency 'rubocop-faker', '~> 1.1'
   s.add_dependency 'rubocop-performance', '~> 1.9'
-  s.add_dependency 'rubocop-rails', '~> 2.11'
+  s.add_dependency 'rubocop-rails', '~> 2.12'
   s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 2.4'
+  s.add_dependency 'rubocop-rspec', '~> 2.5'
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -145,3 +145,7 @@ Rails/UnusedIgnoredColumns:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railseagerevaluationlogmessage
 Rails/EagerEvaluationLogMessage:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundanttravelback
+Rails/RedundantTravelBack:
+  Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -53,3 +53,11 @@ RSpec/Rails/AvoidSetupHook:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecidenticalequalityassertion
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecexcessivedocstringspacing
+RSpec/ExcessiveDocstringSpacing:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecsubjectdeclaration
+RSpec/SubjectDeclaration:
+  Enabled: true


### PR DESCRIPTION
The following rules from the last version have been added:

- Lint/AmbiguousOperatorPrecedence (1.21)
- Lint/IncompatibleIoSelectWithFiberScheduler (1.21)
- Rails/RedundantTravelBack (2.12)
- RSpec/ExcessiveDocstringSpacing (2.5)
- RSpec/SubjectDeclaration (2.5)