### PR TITLE
v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 The following rules have been added:
+## 1.15.0 - 2022-06-02
+  - Added new rules
+    - rubocop
+      - Gemspec/DependencyVersion (1.29)
+      - Gemspec/DeprecatedAttributeAssignment (1.30)
+      - Lint/RefinementImportMethods (1.27)
+      - Security/CompoundHash (1.28)
+      - Style/EnvHome (1.29)
+      - Style/FetchEnvVar (1.28)
+      - Style/MapCompactWithConditionalBlock (1.30)
+      - Style/NestedFileDirname (1.26)
+      - Style/ObjectThen (1.28)
+      - Style/RedundantInitialize (1.27)
+    - rubocop-rails
+      - Rails/I18nLocaleTexts (2.14)
+      - Rails/I18nLazyLookup (2.14)
+      - Rails/MigrationClassName (2.14)
+      - Rails/DuplicateAssociation (2.14)
+      - Rails/DuplicateScope (2.14)
+      - Rails/TransactionExitStatement (2.14)
+      - Rails/DeprecatedActiveModelErrorsMethods (2.14)
+      - Rails/ActionControllerTestCase (2.14)
+      - Rails/TableNameAssignment (2.14)
+    - rubocop-rspec
+      - RSpec/ChangeByZero (2.11.0)
+      - RSpec/VerifiedDoubleReference (2.10.0)
 
 ## 1.14.0 - 2022-03-04
 - Added new rules

--- a/rubocop-gemspec.yml
+++ b/rubocop-gemspec.yml
@@ -9,3 +9,11 @@ Gemspec/DateAssignment:
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa
 Gemspec/RequireMFA:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdependencyversion
+Gemspec/DependencyVersion:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdeprecatedattributeassignment
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -99,3 +99,7 @@ Lint/RequireRelativeSelfPath:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessruby2keywords
 Lint/UselessRuby2Keywords:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintrefinementimportmethods
+Lint/RefinementImportMethods:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.14.0'
+  s.version = '1.15.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'
@@ -47,10 +47,10 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.25'
+  s.add_dependency 'rubocop', '~> 1.30'
   s.add_dependency 'rubocop-faker', '~> 1.1'
-  s.add_dependency 'rubocop-performance', '~> 1.13.2'
-  s.add_dependency 'rubocop-rails', '~> 2.13.2'
-  s.add_dependency 'rubocop-rake', '~> 0.5'
-  s.add_dependency 'rubocop-rspec', '~> 2.9'
+  s.add_dependency 'rubocop-performance', '~> 1.14.0'
+  s.add_dependency 'rubocop-rails', '~> 2.14.2'
+  s.add_dependency 'rubocop-rake', '~> 0.6'
+  s.add_dependency 'rubocop-rspec', '~> 2.11.1'
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -169,3 +169,39 @@ Rails/SchemaComment:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railscompactblank
 Rails/CompactBlank:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsi18nlocaletexts
+Rails/I18nLocaleTexts:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsi18nlazylookup
+Rails/I18nLazyLookup:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsmigrationclassname
+Rails/MigrationClassName:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsduplicateassociation
+Rails/DuplicateAssociation:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsduplicatescope
+Rails/DuplicateScope:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstransactionexitstatement
+Rails/TransactionExitStatement:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdeprecatedactivemodelerrorsmethods
+Rails/DeprecatedActiveModelErrorsMethods:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactioncontrollertestcase
+Rails/ActionControllerTestCase:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstablenameassignment
+Rails/TableNameAssignment:
+  Enabled: false

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -73,3 +73,11 @@ RSpec/BeEq:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbenil
 RSpec/BeNil:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecverifieddoublereference
+RSpec/VerifiedDoubleReference:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecchangebyzero
+RSpec/ChangeByZero:
+  Enabled: true

--- a/rubocop-security.yml
+++ b/rubocop-security.yml
@@ -5,3 +5,7 @@
 # https://docs.rubocop.org/rubocop/cops_security.html#securityiomethods
 Security/IoMethods:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_security.html#securitycompoundhash
+Security/CompoundHash:
+  Enabled: true

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -128,3 +128,27 @@ Style/FileRead:
 # https://docs.rubocop.org/rubocop/cops_style.html#stylefilewrite
 Style/FileWrite:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylenestedfiledirname
+Style/NestedFileDirname:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantinitialize
+Style/RedundantInitialize:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleobjectthen
+Style/ObjectThen:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylefetchenvvar
+Style/FetchEnvVar:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleenvhome
+Style/EnvHome:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylemapcompactwithconditionalblock
+Style/MapCompactWithConditionalBlock:
+  Enabled: true


### PR DESCRIPTION
# Feature/add new rules v1.15.0

- Update gems:
    - rubocop: 1.25 => 1.30
    - rubocop-performance: 1.13.2 => 1.14.0
    - rubocop-rails: 2.13.2 => 2.14.2
    - rubocop-rake: 0.5 => 0.6
    - rubocop-rspec: 2.9 => 2.11.1

- Added new rules
    - rubocop
      - Gemspec/DependencyVersion (1.29)
      - Gemspec/DeprecatedAttributeAssignment (1.30)
      - Lint/RefinementImportMethods (1.27)
      - Security/CompoundHash (1.28)
      - Style/EnvHome (1.29)
      - Style/FetchEnvVar (1.28)
      - Style/MapCompactWithConditionalBlock (1.30)
      - Style/NestedFileDirname (1.26)
      - Style/ObjectThen (1.28)
      - Style/RedundantInitialize (1.27)
    - rubocop-rails
      - Rails/I18nLocaleTexts (2.14)
      - Rails/I18nLazyLookup (2.14)
      - Rails/MigrationClassName (2.14)
      - Rails/DuplicateAssociation (2.14)
      - Rails/DuplicateScope (2.14)
      - Rails/TransactionExitStatement (2.14)
      - Rails/DeprecatedActiveModelErrorsMethods (2.14)
      - Rails/ActionControllerTestCase (2.14)
      - Rails/TableNameAssignment (2.14)
    - rubocop-rspec
      - RSpec/ChangeByZero (2.11.0)
      - RSpec/VerifiedDoubleReference (2.10.0)