### PR TITLE
v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 The following rules have been added:
+## 1.16.0 - 2022-09-01
+  - Added new rules
+    - rubocop
+      - Lint/NonAtomicFileOperation (1.31.0)
+      - Layout/LineContinuationLeadingSpace (1.31.0)
+      - Layout/LineContinuationSpacing (1.31.0)
+      - Style/EmptyHeredoc (1.32.0)
+      - Layout/MultilineMethodParameterLineBreaks (1.32.0)
+      - Lint/RequireRangeParentheses (1.32.0)
+      - Style/MagicCommentFormat (1.35.0)
+    - rubocop-rails
+      - Rails/DotSeparatedKeys (1.15.0)
+      - Rails/StripHeredoc (1.15.0)
+      - Rails/ToFormattedS (1.15.0)
+      - Rails/RootPublicPath (1.15.0)
+    - rubocop-rspec
+      - RSpec/Capybara/SpecificMatcher (2.12.0)
+      - RSpec/Rails/HaveHttpStatus (2.12.0)
+  - Removed rules
+    - rubocop
+      - Gemspec/DateAssignment
 ## 1.15.0 - 2022-06-02
   - Added new rules
     - rubocop

--- a/rubocop-gemspec.yml
+++ b/rubocop-gemspec.yml
@@ -2,10 +2,6 @@
 ## https://rubocop.readthedocs.io/en/latest/cops_gemspec/
 #
 
-# https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdateassignment
-Gemspec/DateAssignment:
-  Enabled: true
-
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa
 Gemspec/RequireMFA:
   Enabled: true
@@ -17,3 +13,4 @@ Gemspec/DependencyVersion:
 # https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdeprecatedattributeassignment
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
+

--- a/rubocop-layout.yml
+++ b/rubocop-layout.yml
@@ -26,3 +26,15 @@ Layout/SpaceBeforeBrackets:
 Layout/LineEndStringConcatenationIndentation:
   Enabled: true
   EnforcedStyle: aligned
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationleadingspace
+Layout/LineContinuationLeadingSpace:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationspacing
+Layout/LineContinuationSpacing:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilinemethodparameterlinebreaks
+Layout/MultilineMethodParameterLineBreaks:
+  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -103,3 +103,15 @@ Lint/UselessRuby2Keywords:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintrefinementimportmethods
 Lint/RefinementImportMethods:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintnonatomicfileoperation
+Lint/NonAtomicFileOperation:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintconstantoverwritteninrescue
+Lint/ConstantOverwrittenInRescue:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintrequirerangeparentheses
+Lint/RequireRangeParentheses:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.15.0'
+  s.version = '1.16.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'
@@ -47,10 +47,10 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.30'
-  s.add_dependency 'rubocop-faker', '~> 1.1'
-  s.add_dependency 'rubocop-performance', '~> 1.14.0'
-  s.add_dependency 'rubocop-rails', '~> 2.14.2'
-  s.add_dependency 'rubocop-rake', '~> 0.6'
-  s.add_dependency 'rubocop-rspec', '~> 2.11.1'
+  s.add_dependency 'rubocop', '~> 1.35.1'
+  s.add_dependency 'rubocop-faker', '~> 1.1.0'
+  s.add_dependency 'rubocop-performance', '~> 1.14.3'
+  s.add_dependency 'rubocop-rails', '~> 2.15.2'
+  s.add_dependency 'rubocop-rake', '~> 0.6.0'
+  s.add_dependency 'rubocop-rspec', '~> 2.12.1'
 end

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -205,3 +205,19 @@ Rails/ActionControllerTestCase:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstablenameassignment
 Rails/TableNameAssignment:
   Enabled: false
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdotseparatedkeys
+Rails/DotSeparatedKeys:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsstripheredoc
+Rails/StripHeredoc:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstoformatteds
+Rails/ToFormattedS:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpublicpath
+Rails/RootPublicPath:
+  Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -81,3 +81,11 @@ RSpec/VerifiedDoubleReference:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecchangebyzero
 RSpec/ChangeByZero:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificmatcher
+RSpec/Capybara/SpecificMatcher:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailshavehttpstatus
+RSpec/Rails/HaveHttpStatus:
+  Enabled: true

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -152,3 +152,12 @@ Style/EnvHome:
 # https://docs.rubocop.org/rubocop/cops_style.html#stylemapcompactwithconditionalblock
 Style/MapCompactWithConditionalBlock:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleemptyheredoc
+Style/EmptyHeredoc:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylemagiccommentformat
+Style/MagicCommentFormat:
+  Enabled: true
+  EnforcedStyle: snake_case


### PR DESCRIPTION
# Feature/add new rules v1.16.0

- Update gems:
   - rubocop: 1.30 => 1.35.1
   - rubocop-performance: 1.14.0 => 1.14.3
   - rubocop-rails: 2.14.2 => 2.15.2
   - rubocop-rspec:  2.11.1 => 2.12.1
   
- Added new rules
  - rubocop
    - Lint/NonAtomicFileOperation (1.31.0)
    - Layout/LineContinuationLeadingSpace (1.31.0)
    - Layout/LineContinuationSpacing (1.31.0)
    - Style/EmptyHeredoc (1.32.0)
    - Layout/MultilineMethodParameterLineBreaks (1.32.0)
    - Lint/RequireRangeParentheses (1.32.0)
    - Style/MagicCommentFormat (1.35.0)
  - rubocop-rails
    - Rails/DotSeparatedKeys (1.15.0)
    - Rails/StripHeredoc (1.15.0)
    - Rails/ToFormattedS (1.15.0)
    - Rails/RootPublicPath (1.15.0)
  - rubocop-rspec
    - RSpec/Capybara/SpecificMatcher (2.12.0)
    - RSpec/Rails/HaveHttpStatus (2.12.0)
 - Removed rules
   - rubocop
     - Gemspec/DateAssignment