### PR TITLE
v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 The following rules have been added:
+## 1.17.0 - 2023-03-14
+  - Added rubocop-capybara as deprecation rules in rubocop-rspec 2.18.0 [link](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.18.0)
+  - Added new rules
+    - rubocop
+      - Lint/DuplicateMagicComment (1.37.0)
+      - Style/OperatorMethodCall (1.37.0)
+      - Style/RedundantStringEscape (1.37.0)
+      - Style/RedundantEach (1.38.0)
+      - Style/RedundantConstantBase (1.40.0)
+      - Style/RequireOrder (1.40.0)
+      - Style/ArrayIntersect (1.40.0)
+      - Style/RedundantDoubleSplatHashBraces (1.41.0)
+      - Style/ConcatArrayLiterals (1.41.0)
+      - Style/MapToSet (1.42.0)
+      - Style/MinMaxComparison (1.42.0)
+      - Style/YodaExpression (1.42.0)
+      - Lint/UselessRescue (1.43.0)
+      - Style/InvertibleUnlessCondition (1.44.0)
+      - Style/ComparableClamp (1.44.0)
+      - Gemspec/DevelopmentDependencies (1.44.0)
+      - Style/RedundantHeredocDelimiterQuotes (1.45.0)
+      - Metrics/CollectionLiteralLength (1.47.0)
+      - Style/DirEmpty (1.48.0)
+      - Style/FileEmpty (1.48.0)
+    - rubocop-rails
+      - Rails/FreezeTime (2.16.0)
+      - Rails/WhereMissing (2.16.0)
+      - Rails/RootPathnameMethods (2.16.0)
+      - Rails/TopLevelHashWithIndifferentAccess (2.16.0)
+      - Rails/ActionControllerFlashBeforeRender (2.16.0)
+      - Rails/ActiveSupportOnLoad (2.16.0)
+      - Rails/ToSWithArgument (2.16.0)
+      - Rails/ActionOrder (2.17.0)
+      - Rails/WhereNotWithMultipleConditions (2.17.0)
+      - Rails/IgnoredColumnsAssignment (2.17.0)
+      - Rails/ResponseParsedBody (2.18.0)
+    - rubocop-performance:
+      - Performance/ConcurrentMonotonicTime (1.12.0)
+    - rubocop-rspec
+      - RSpec/NoExpectationExample (2.13.0)
+      - RSpec/ClassCheck (2.13.0)
+      - RSpec/FactoryBot/ConsistentParenthesesStyle (2.14.0)
+      - RSpec/Rails/InferredSpecType (2.14.0)
+      - RSpec/SortMetadata (2.14.0)
+      - RSpec/FactoryBot/FactoryNameStyle (2.16.0)
+      - RSpec/DuplicatedMetadata (2.16.0)
+      - RSpec/PendingWithoutReason (2.16.0)
+      - RSpec/Rails/MinitestAssertions (2.17.0)
+      - RSpec/RedundantAround (2.19.0)
+      - RSpec/Rails/TravelAround (2.19.0)
+      - RSpec/ContainExactly (2.19.0)
+      - RSpec/MatchArray (2.19.0)
+      - RSpec/SkipBlockInsideExample (2.19.0)
+    - rubocop-capybara
+      - Capybara/SpecificFinders (2.17.1)
+      - Capybara/NegationMatcher (2.17.1)
+      - Capybara/SpecificActions (2.17.1)
+      - Capybara/MatchStyle (2.17.1)
+
 ## 1.16.0 - 2022-09-01
   - Added new rules
     - rubocop

--- a/rubocop-capybara.yml
+++ b/rubocop-capybara.yml
@@ -1,0 +1,26 @@
+#
+## https://github.com/rubocop/rubocop-capybara/
+#
+
+require: rubocop-capybara
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificmatcher
+Capybara/SpecificMatcher:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificfinders
+Capybara/SpecificFinders:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaranegationmatcher
+Capybara/NegationMatcher:
+  Enabled: true
+  EnforcedStyle: have_no
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificactions
+Capybara/SpecificActions:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaramatchstyle
+Capybara/MatchStyle:
+  Enabled: true

--- a/rubocop-default.yml
+++ b/rubocop-default.yml
@@ -1,12 +1,17 @@
 inherit_from:
   - rubocop-all.yml
   - rubocop-bundler.yml
+  - rubocop-capybara.yml
+  - rubocop-faker.yml
   - rubocop-gemspec.yml
   - rubocop-layout.yml
   - rubocop-lint.yml
   - rubocop-metrics.yml
   - rubocop-naming.yml
   - rubocop-performance.yml
+  - rubocop-rails.yml
+  - rubocop-rake.yml
+  - rubocop-rspec.yml
   - rubocop-security.yml
   - rubocop-style.yml
 

--- a/rubocop-gemspec.yml
+++ b/rubocop-gemspec.yml
@@ -14,3 +14,6 @@ Gemspec/DependencyVersion:
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 
+# https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdevelopmentdependencies
+Gemspec/DevelopmentDependencies:
+  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -115,3 +115,11 @@ Lint/ConstantOverwrittenInRescue:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintrequirerangeparentheses
 Lint/RequireRangeParentheses:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicatemagiccomment
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessrescue
+Lint/UselessRescue:
+  Enabled: true

--- a/rubocop-metrics.yml
+++ b/rubocop-metrics.yml
@@ -29,3 +29,8 @@ Metrics/BlockLength:
     - "**/config/routes.rb"
     - "**/config/routes/**/*.rb"
     - "**/lib/tasks/auto_annotate_models.rake"
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricscollectionliterallength
+Metrics/CollectionLiteralLength:
+  Enabled: true
+  LengthThreshold: 250

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.16.0'
+  s.version = '1.17.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'
@@ -47,10 +47,11 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.35.1'
+  s.add_dependency 'rubocop', '~> 1.48.1'
+  s.add_dependency 'rubocop-capybara', '~> 2.17.1'
   s.add_dependency 'rubocop-faker', '~> 1.1.0'
-  s.add_dependency 'rubocop-performance', '~> 1.14.3'
-  s.add_dependency 'rubocop-rails', '~> 2.15.2'
+  s.add_dependency 'rubocop-performance', '~> 1.16.0'
+  s.add_dependency 'rubocop-rails', '~> 2.18.0'
   s.add_dependency 'rubocop-rake', '~> 0.6.0'
-  s.add_dependency 'rubocop-rspec', '~> 2.12.1'
+  s.add_dependency 'rubocop-rspec', '~> 2.19.0'
 end

--- a/rubocop-performance.yml
+++ b/rubocop-performance.yml
@@ -75,3 +75,7 @@ Performance/RedundantSplitRegexpArgument:
 # https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancestringidentifierargument
 Performance/StringIdentifierArgument:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceconcurrentmonotonictime
+Performance/ConcurrentMonotonicTime:
+  Enabled: true

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -58,6 +58,10 @@ Rails/ActiveRecordCallbacksOrder:
 Rails/FindById:
   Enabled: true
 
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfindeach
+Rails/FindEach:
+  Enabled: true
+
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsinquiry
 Rails/Inquiry:
   Enabled: true
@@ -220,4 +224,48 @@ Rails/ToFormattedS:
 
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpublicpath
 Rails/RootPublicPath:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfreezetime
+Rails/FreezeTime:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswheremissing
+Rails/WhereMissing:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpathnamemethods
+Rails/RootPathnameMethods:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstoplevelhashwithindifferentaccess
+Rails/TopLevelHashWithIndifferentAccess:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactioncontrollerflashbeforerender
+Rails/ActionControllerFlashBeforeRender:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactivesupportonload
+Rails/ActiveSupportOnLoad:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstoswithargument
+Rails/ToSWithArgument:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactionorder
+Rails/ActionOrder:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswherenotwithmultipleconditions
+Rails/WhereNotWithMultipleConditions:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsignoredcolumnsassignment
+Rails/IgnoredColumnsAssignment:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsresponseparsedbody
+Rails/ResponseParsedBody:
   Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -82,10 +82,63 @@ RSpec/VerifiedDoubleReference:
 RSpec/ChangeByZero:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificmatcher
-RSpec/Capybara/SpecificMatcher:
-  Enabled: true
-
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailshavehttpstatus
 RSpec/Rails/HaveHttpStatus:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnoexpectationexample
+RSpec/NoExpectationExample:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecclasscheck
+RSpec/ClassCheck:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotconsistentparenthesesstyle
+RSpec/FactoryBot/ConsistentParenthesesStyle:
+  Enabled: true
+  EnforcedStyle: "require_parentheses"
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsinferredspectype
+RSpec/Rails/InferredSpecType:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecsortmetadata
+RSpec/SortMetadata:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotfactorynamestyle
+RSpec/FactoryBot/FactoryNameStyle:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecduplicatedmetadata
+RSpec/DuplicatedMetadata:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecpendingwithoutreason
+RSpec/PendingWithoutReason:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsminitestassertions
+RSpec/Rails/MinitestAssertions:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecredundantaround
+RSpec/RedundantAround:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailstravelaround
+RSpec/Rails/TravelAround:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspeccontainexactly
+RSpec/ContainExactly:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmatcharray
+RSpec/MatchArray:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecskipblockinsideexample
+RSpec/SkipBlockInsideExample:
   Enabled: true

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -161,3 +161,67 @@ Style/EmptyHeredoc:
 Style/MagicCommentFormat:
   Enabled: true
   EnforcedStyle: snake_case
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleoperatormethodcall
+Style/OperatorMethodCall:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantstringescape
+Style/RedundantStringEscape:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundanteach
+Style/RedundantEach:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantconstantbase
+Style/RedundantConstantBase:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylerequireorder
+Style/RequireOrder:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylearrayintersect
+Style/ArrayIntersect:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantdoublesplathashbraces
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleconcatarrayliterals
+Style/ConcatArrayLiterals:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylemaptoset
+Style/MapToSet:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleminmaxcomparison
+Style/MinMaxComparison:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleyodaexpression
+Style/YodaExpression:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleinvertibleunlesscondition
+Style/InvertibleUnlessCondition:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylecomparableclamp
+Style/ComparableClamp:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantheredocdelimiterquotes
+Style/RedundantHeredocDelimiterQuotes:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styledirempty
+Style/DirEmpty:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylefileempty
+Style/FileEmpty:
+  Enabled: true


### PR DESCRIPTION
# Feature/add new rules v1.17.0

- New gems:
   - rubocop-capybara: 2.17.1
- Update gems:
   - rubocop: 1.35.1 => 1.48.1
   - rubocop-performance: 1.15.2 => 1.16.0
   - rubocop-rails: 2.15.2 => 2.18.0
   - rubocop-rspec:  2.12.1 => 2.19.0
   
- Added new rules
    - rubocop
      - Lint/DuplicateMagicComment (1.37.0)
      - Style/OperatorMethodCall (1.37.0)
      - Style/RedundantStringEscape (1.37.0)
      - Style/RedundantEach (1.38.0)
      - Style/RedundantConstantBase (1.40.0)
      - Style/RequireOrder (1.40.0)
      - Style/ArrayIntersect (1.40.0)
      - Style/RedundantDoubleSplatHashBraces (1.41.0)
      - Style/ConcatArrayLiterals (1.41.0)
      - Style/MapToSet (1.42.0)
      - Style/MinMaxComparison (1.42.0)
      - Style/YodaExpression (1.42.0)
      - Lint/UselessRescue (1.43.0)
      - Style/InvertibleUnlessCondition (1.44.0)
      - Style/ComparableClamp (1.44.0)
      - Gemspec/DevelopmentDependencies (1.44.0)
      - Style/RedundantHeredocDelimiterQuotes (1.45.0)
      - Metrics/CollectionLiteralLength (1.47.0)
      - Style/DirEmpty (1.48.0)
      - Style/FileEmpty (1.48.0)
    - rubocop-rails
      - Rails/FreezeTime (2.16.0)
      - Rails/WhereMissing (2.16.0)
      - Rails/RootPathnameMethods (2.16.0)
      - Rails/TopLevelHashWithIndifferentAccess (2.16.0)
      - Rails/ActionControllerFlashBeforeRender (2.16.0)
      - Rails/ActiveSupportOnLoad (2.16.0)
      - Rails/ToSWithArgument (2.16.0)
      - Rails/ActionOrder (2.17.0)
      - Rails/WhereNotWithMultipleConditions (2.17.0)
      - Rails/IgnoredColumnsAssignment (2.17.0)
      - Rails/ResponseParsedBody (2.18.0)
    - rubocop-performance:
      - Performance/ConcurrentMonotonicTime (1.12.0)
    - rubocop-rspec
      - RSpec/NoExpectationExample (2.13.0)
      - RSpec/ClassCheck (2.13.0)
      - RSpec/FactoryBot/ConsistentParenthesesStyle (2.14.0)
      - RSpec/Rails/InferredSpecType (2.14.0)
      - RSpec/SortMetadata (2.14.0)
      - RSpec/FactoryBot/FactoryNameStyle (2.16.0)
      - RSpec/DuplicatedMetadata (2.16.0)
      - RSpec/PendingWithoutReason (2.16.0)
      - RSpec/Rails/MinitestAssertions (2.17.0)
      - RSpec/RedundantAround (2.19.0)
      - RSpec/Rails/TravelAround (2.19.0)
      - RSpec/ContainExactly (2.19.0)
      - RSpec/MatchArray (2.19.0)
      - RSpec/SkipBlockInsideExample (2.19.0)
    - rubocop-capybara
      - Capybara/SpecificFinders (2.17.1)
      - Capybara/NegationMatcher (2.17.1)
      - Capybara/SpecificActions (2.17.1)
      - Capybara/MatchStyle (2.17.1)