### PR TITLE
v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,114 +6,166 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 The following rules have been added:
+
+## 1.18.0 - 2023-10-17
+
+- Added new rules
+  - rubocop
+    - Style/RedundantLineContinuation (1.49.0)
+    - Style/DataInheritance (1.49.0)
+    - Lint/DuplicateMatchPattern (1.50.0)
+    - Style/ExactRegexpMatch (1.51.0)
+    - Style/RedundantArrayConstructor (1.52.0)
+    - Style/RedundantRegexpConstructor (1.52.0)
+    - Style/RedundantFilterChain (1.52.0)
+    - Lint/MixedCaseRange (1.53.0)
+    - Lint/RedundantRegexpQuantifiers (1.53.0)
+    - Style/RedundantCurrentDirectoryInPath (1.53.0)
+    - Style/ReturnNilInPredicateMethodDefinition (1.53.0)
+    - Style/YAMLFileRead (1.53.0)
+    - Bundler/DuplicatedGroup (1.56.0)
+    - Style/SingleLineDoEndBlock (1.57.0)
+  - rubocop-capybara
+    - Capybara/RSpec/PredicateMatcher (2.19.0)
+    - Capybara/RSpec/HaveSelector (2.19.0)
+    - Capybara/ClickLinkOrButtonStyle (2.19.0)
+  - rubocop-performance
+    - Performance/MapMethodChain (1.19.0)
+  - rubocop-rails
+    - Rails/ThreeStateBooleanColumn (2.19.0)
+    - Rails/SelectMap (2.21.0)
+    - Rails/DangerousColumnNames (2.21.0)
+    - Rails/UnusedRenderContent (2.21.0)
+    - Rails/RedundantActiveRecordAllMethod (2.21.0)
+  - rubocop-rspec
+    - RSpec/IndexedLet (2.20.0)
+    - RSpec/BeEmpty (2.20.0)
+    - RSpec/Rails/NegationBeValid (2.23.0)
+    - RSpec/ReceiveMessages (2.23.0)
+    - RSpec/EmptyMetadata (2.24.0)
+    - RSpec/Eq (2.24.0)
+    - RSpec/MetadataStyle (2.24.0)
+    - RSpec/SpecFilePathFormat (2.24.0)
+    - RSpec/SpecFilePathSuffix (2.24.0)
+  - rubocop-factory_bot
+    - FactoryBot/AssociationStyle (2.23.0)
+    - FactoryBot/FactoryAssociationWithStrategy (2.23.0)
+    - FactoryBot/IdSequence (2.23.0)
+    - FactoryBot/RedundantFactoryOption (2.23.0)
+
 ## 1.17.0 - 2023-03-14
-  - Added rubocop-capybara as deprecation rules in rubocop-rspec 2.18.0 [link](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.18.0)
-  - Added new rules
-    - rubocop
-      - Lint/DuplicateMagicComment (1.37.0)
-      - Style/OperatorMethodCall (1.37.0)
-      - Style/RedundantStringEscape (1.37.0)
-      - Style/RedundantEach (1.38.0)
-      - Style/RedundantConstantBase (1.40.0)
-      - Style/RequireOrder (1.40.0)
-      - Style/ArrayIntersect (1.40.0)
-      - Style/RedundantDoubleSplatHashBraces (1.41.0)
-      - Style/ConcatArrayLiterals (1.41.0)
-      - Style/MapToSet (1.42.0)
-      - Style/MinMaxComparison (1.42.0)
-      - Style/YodaExpression (1.42.0)
-      - Lint/UselessRescue (1.43.0)
-      - Style/InvertibleUnlessCondition (1.44.0)
-      - Style/ComparableClamp (1.44.0)
-      - Gemspec/DevelopmentDependencies (1.44.0)
-      - Style/RedundantHeredocDelimiterQuotes (1.45.0)
-      - Metrics/CollectionLiteralLength (1.47.0)
-      - Style/DirEmpty (1.48.0)
-      - Style/FileEmpty (1.48.0)
-    - rubocop-rails
-      - Rails/FreezeTime (2.16.0)
-      - Rails/WhereMissing (2.16.0)
-      - Rails/RootPathnameMethods (2.16.0)
-      - Rails/TopLevelHashWithIndifferentAccess (2.16.0)
-      - Rails/ActionControllerFlashBeforeRender (2.16.0)
-      - Rails/ActiveSupportOnLoad (2.16.0)
-      - Rails/ToSWithArgument (2.16.0)
-      - Rails/ActionOrder (2.17.0)
-      - Rails/WhereNotWithMultipleConditions (2.17.0)
-      - Rails/IgnoredColumnsAssignment (2.17.0)
-      - Rails/ResponseParsedBody (2.18.0)
-    - rubocop-performance:
-      - Performance/ConcurrentMonotonicTime (1.12.0)
-    - rubocop-rspec
-      - RSpec/NoExpectationExample (2.13.0)
-      - RSpec/ClassCheck (2.13.0)
-      - RSpec/FactoryBot/ConsistentParenthesesStyle (2.14.0)
-      - RSpec/Rails/InferredSpecType (2.14.0)
-      - RSpec/SortMetadata (2.14.0)
-      - RSpec/FactoryBot/FactoryNameStyle (2.16.0)
-      - RSpec/DuplicatedMetadata (2.16.0)
-      - RSpec/PendingWithoutReason (2.16.0)
-      - RSpec/Rails/MinitestAssertions (2.17.0)
-      - RSpec/RedundantAround (2.19.0)
-      - RSpec/Rails/TravelAround (2.19.0)
-      - RSpec/ContainExactly (2.19.0)
-      - RSpec/MatchArray (2.19.0)
-      - RSpec/SkipBlockInsideExample (2.19.0)
-    - rubocop-capybara
-      - Capybara/SpecificFinders (2.17.1)
-      - Capybara/NegationMatcher (2.17.1)
-      - Capybara/SpecificActions (2.17.1)
-      - Capybara/MatchStyle (2.17.1)
+
+- Added rubocop-capybara as deprecation rules in rubocop-rspec 2.18.0 [link](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.18.0)
+- Added new rules
+  - rubocop
+    - Lint/DuplicateMagicComment (1.37.0)
+    - Style/OperatorMethodCall (1.37.0)
+    - Style/RedundantStringEscape (1.37.0)
+    - Style/RedundantEach (1.38.0)
+    - Style/RedundantConstantBase (1.40.0)
+    - Style/RequireOrder (1.40.0)
+    - Style/ArrayIntersect (1.40.0)
+    - Style/RedundantDoubleSplatHashBraces (1.41.0)
+    - Style/ConcatArrayLiterals (1.41.0)
+    - Style/MapToSet (1.42.0)
+    - Style/MinMaxComparison (1.42.0)
+    - Style/YodaExpression (1.42.0)
+    - Lint/UselessRescue (1.43.0)
+    - Style/InvertibleUnlessCondition (1.44.0)
+    - Style/ComparableClamp (1.44.0)
+    - Gemspec/DevelopmentDependencies (1.44.0)
+    - Style/RedundantHeredocDelimiterQuotes (1.45.0)
+    - Metrics/CollectionLiteralLength (1.47.0)
+    - Style/DirEmpty (1.48.0)
+    - Style/FileEmpty (1.48.0)
+  - rubocop-rails
+    - Rails/FreezeTime (2.16.0)
+    - Rails/WhereMissing (2.16.0)
+    - Rails/RootPathnameMethods (2.16.0)
+    - Rails/TopLevelHashWithIndifferentAccess (2.16.0)
+    - Rails/ActionControllerFlashBeforeRender (2.16.0)
+    - Rails/ActiveSupportOnLoad (2.16.0)
+    - Rails/ToSWithArgument (2.16.0)
+    - Rails/ActionOrder (2.17.0)
+    - Rails/WhereNotWithMultipleConditions (2.17.0)
+    - Rails/IgnoredColumnsAssignment (2.17.0)
+    - Rails/ResponseParsedBody (2.18.0)
+  - rubocop-performance:
+    - Performance/ConcurrentMonotonicTime (1.12.0)
+  - rubocop-rspec
+    - RSpec/NoExpectationExample (2.13.0)
+    - RSpec/ClassCheck (2.13.0)
+    - RSpec/FactoryBot/ConsistentParenthesesStyle (2.14.0)
+    - RSpec/Rails/InferredSpecType (2.14.0)
+    - RSpec/SortMetadata (2.14.0)
+    - RSpec/FactoryBot/FactoryNameStyle (2.16.0)
+    - RSpec/DuplicatedMetadata (2.16.0)
+    - RSpec/PendingWithoutReason (2.16.0)
+    - RSpec/Rails/MinitestAssertions (2.17.0)
+    - RSpec/RedundantAround (2.19.0)
+    - RSpec/Rails/TravelAround (2.19.0)
+    - RSpec/ContainExactly (2.19.0)
+    - RSpec/MatchArray (2.19.0)
+    - RSpec/SkipBlockInsideExample (2.19.0)
+  - rubocop-capybara
+    - Capybara/SpecificFinders (2.17.1)
+    - Capybara/NegationMatcher (2.17.1)
+    - Capybara/SpecificActions (2.17.1)
+    - Capybara/MatchStyle (2.17.1)
 
 ## 1.16.0 - 2022-09-01
-  - Added new rules
-    - rubocop
-      - Lint/NonAtomicFileOperation (1.31.0)
-      - Layout/LineContinuationLeadingSpace (1.31.0)
-      - Layout/LineContinuationSpacing (1.31.0)
-      - Style/EmptyHeredoc (1.32.0)
-      - Layout/MultilineMethodParameterLineBreaks (1.32.0)
-      - Lint/RequireRangeParentheses (1.32.0)
-      - Style/MagicCommentFormat (1.35.0)
-    - rubocop-rails
-      - Rails/DotSeparatedKeys (1.15.0)
-      - Rails/StripHeredoc (1.15.0)
-      - Rails/ToFormattedS (1.15.0)
-      - Rails/RootPublicPath (1.15.0)
-    - rubocop-rspec
-      - RSpec/Capybara/SpecificMatcher (2.12.0)
-      - RSpec/Rails/HaveHttpStatus (2.12.0)
-  - Removed rules
-    - rubocop
-      - Gemspec/DateAssignment
+
+- Added new rules
+  - rubocop
+    - Lint/NonAtomicFileOperation (1.31.0)
+    - Layout/LineContinuationLeadingSpace (1.31.0)
+    - Layout/LineContinuationSpacing (1.31.0)
+    - Style/EmptyHeredoc (1.32.0)
+    - Layout/MultilineMethodParameterLineBreaks (1.32.0)
+    - Lint/RequireRangeParentheses (1.32.0)
+    - Style/MagicCommentFormat (1.35.0)
+  - rubocop-rails
+    - Rails/DotSeparatedKeys (1.15.0)
+    - Rails/StripHeredoc (1.15.0)
+    - Rails/ToFormattedS (1.15.0)
+    - Rails/RootPublicPath (1.15.0)
+  - rubocop-rspec
+    - RSpec/Capybara/SpecificMatcher (2.12.0)
+    - RSpec/Rails/HaveHttpStatus (2.12.0)
+- Removed rules
+  - rubocop
+    - Gemspec/DateAssignment
+
 ## 1.15.0 - 2022-06-02
-  - Added new rules
-    - rubocop
-      - Gemspec/DependencyVersion (1.29)
-      - Gemspec/DeprecatedAttributeAssignment (1.30)
-      - Lint/RefinementImportMethods (1.27)
-      - Security/CompoundHash (1.28)
-      - Style/EnvHome (1.29)
-      - Style/FetchEnvVar (1.28)
-      - Style/MapCompactWithConditionalBlock (1.30)
-      - Style/NestedFileDirname (1.26)
-      - Style/ObjectThen (1.28)
-      - Style/RedundantInitialize (1.27)
-    - rubocop-rails
-      - Rails/I18nLocaleTexts (2.14)
-      - Rails/I18nLazyLookup (2.14)
-      - Rails/MigrationClassName (2.14)
-      - Rails/DuplicateAssociation (2.14)
-      - Rails/DuplicateScope (2.14)
-      - Rails/TransactionExitStatement (2.14)
-      - Rails/DeprecatedActiveModelErrorsMethods (2.14)
-      - Rails/ActionControllerTestCase (2.14)
-      - Rails/TableNameAssignment (2.14)
-    - rubocop-rspec
-      - RSpec/ChangeByZero (2.11.0)
-      - RSpec/VerifiedDoubleReference (2.10.0)
+
+- Added new rules
+  - rubocop
+    - Gemspec/DependencyVersion (1.29)
+    - Gemspec/DeprecatedAttributeAssignment (1.30)
+    - Lint/RefinementImportMethods (1.27)
+    - Security/CompoundHash (1.28)
+    - Style/EnvHome (1.29)
+    - Style/FetchEnvVar (1.28)
+    - Style/MapCompactWithConditionalBlock (1.30)
+    - Style/NestedFileDirname (1.26)
+    - Style/ObjectThen (1.28)
+    - Style/RedundantInitialize (1.27)
+  - rubocop-rails
+    - Rails/I18nLocaleTexts (2.14)
+    - Rails/I18nLazyLookup (2.14)
+    - Rails/MigrationClassName (2.14)
+    - Rails/DuplicateAssociation (2.14)
+    - Rails/DuplicateScope (2.14)
+    - Rails/TransactionExitStatement (2.14)
+    - Rails/DeprecatedActiveModelErrorsMethods (2.14)
+    - Rails/ActionControllerTestCase (2.14)
+    - Rails/TableNameAssignment (2.14)
+  - rubocop-rspec
+    - RSpec/ChangeByZero (2.11.0)
+    - RSpec/VerifiedDoubleReference (2.10.0)
 
 ## 1.14.0 - 2022-03-04
+
 - Added new rules
   - rubocop-rails
     - Rails/CompactBlank (2.13)
@@ -124,6 +176,7 @@ The following rules have been added:
     - RSpec/BeNil (2.9)
 
 ## 1.13.0 - 2022-02-25
+
 - Added new rules
   - rubocop
     - Lint/UselessRuby2Keywords (1.23)
@@ -142,9 +195,11 @@ The following rules have been added:
     - RSpec/FactoryBot/SyntaxMethods (2.7.0)
 
 ## 1.12.1 - 2021-10-13
+
 - No new changes. Previous gem was yanked.
 
 ## 1.12.0 - 2021-10-13
+
 - Added new rules
   - rubocop
     - Lint/RequireRelativeSelfPath (1.22)
@@ -154,6 +209,7 @@ The following rules have been added:
     - Style/SelectByRegexp (1.22)
 
 ## 1.11.0 - 2021-09-28
+
 - Added new rules
   - rubocop
     - Lint/AmbiguousOperatorPrecedence (1.21)
@@ -165,38 +221,47 @@ The following rules have been added:
     - RSpec/SubjectDeclaration (2.5)
 
 ### Changed
+
 - Updated dependency rubocop to 1.21
 - Updated dependency rubocop-rails to 2.12
 - Updated dependency rubocop-rspec to 2.5
 
 ## 1.10.0 - 2021-08-25
+
 ### Changed
+
 - Layout/SpaceAroundEqualsInParameterDefault has been changed to the default value (aka space)
 
 ## 1.9.0 - 2021-08-18
+
 - Added new rules introduced in the 1.19 version.
   - rubocop
     - Lint/AmbiguousRange
     - Style/RedundantSelfAssignmentBranch
 
 ### Changed
+
 - Updated dependency rubocop to 1.19
 
 ## 1.8.1 - 2021-07-26
 
 ### Changed
+
 - `config/routes/` directory should have the same rules as `config/routes.rb`
 
 ## 1.8.0 - 2021-06-29
+
 - Added new rules introduced in the last version.
   - rubocop
     - Layout/LineEndStringConcatenationIndentation (1.18)
     - Naming/InclusiveLanguage (1.18)
 
 ### Changed
+
 - Updated dependency rubocop
 
 ## 1.7.0 - 2021-06-29
+
 - Added new rules introduced in the last version.
   - rubocop-rails
     - Rails/AddColumnIndex (2.11)
@@ -209,11 +274,13 @@ The following rules have been added:
     - RSpec/Rails/AvoidSetupHook (2.4)
 
 ### Changed
+
 - Updated dependency rubocop-rails and rubocop-rspec
 
 ## 1.6.0 - 2021-06-08
 
 ### Added
+
 - Added new rules introduced in the last version.
   - rubocop
     - Lint/EmptyInPattern (1.16)
@@ -229,11 +296,13 @@ The following rules have been added:
     - Rails/TimeZoneAssignment (2.10)
 
 ### Changed
+
 - Updated dependency rubocop-rails
 
 ## 1.5.0 - 2021-02-25
 
 ### Added
+
 - Added new rules introduced in the last version.
   - rubocop
     - Gemspec/DateAssignment (1.10)
@@ -252,7 +321,9 @@ The following rules have been added:
     - Style/IfWithBooleanLiteralBranches (1.9)
 
 ## 1.4.0 - 2020-12-15
+
 ### Added
+
 - Added new rules introduced in the last version.
   - rubocop
     - Lint/UnexpectedBlockArity (1.5)
@@ -261,7 +332,9 @@ The following rules have been added:
     - Rails/WhereEquals (2.9)
 
 ## 1.3.0 - 2020-11-25
+
 ### Added
+
 - Added new rules introduced in the last version.
   - rubocop
     - Style/RedundantArgument (1.4)
@@ -273,24 +346,31 @@ The following rules have been added:
     - Performance/MethodObjectAsBlock (1.9)
 
 ## 1.2.0 - 2020-11-13
+
 ### Added
+
 - Added new rules introduced in the last version.
   - Lint/DuplicateBranch (1.3)
   - Lint/EmptyClass (1.3)
   - Style/NilLambda (1.3)
 
 ## 1.1.0 - 2020-11-13
+
 ### Added
+
 - Added new rules introduced in the last version.
   - Lint/NoReturnInBeginEndBlocks (1.2)
   - Style/CollectionCompact (1.2)
   - Style/NegatedIfElseCondition (1.2)
 
 ### Changed
+
 - Changed Naming/VariableNumber to start using snake_case
 
 ## 1.0.0 - 2020-11-04
+
 ### Added
+
 - Added new rules introduced in the last version.
   - Lint/DuplicateRegexpCharacterClassElement (1.1)
   - Lint/EmptyBlock (1.1)
@@ -303,15 +383,18 @@ The following rules have been added:
   - RSpec/Rails/HttpStatus (2.pre)
 
 ### Changed
+
 - Removed shared enabled rules with rubocop 1.0
 - Bump dependencies (rubocop 1.0 and rubocop-rspec 2.pre)
 - Bump ruby version to use `...`
 - Reordered some rules following the convention of namespace/file.
 
-
 ## 0.10.0 - 2020-11-04
+
 ### Added
+
 - Added new rules introduced in the last version.
+
   - Lint/HashCompareByIdentity (0.93)
   - Lint/RedundantSafeNavigation (0.93)
   - Style/ClassEqualityComparison (0.93)
@@ -320,10 +403,13 @@ The following rules have been added:
   - RSpec/StubbedMock (1.44)
 
 ### Changed
+
 - Bump dependencies
 
 ## 0.9.0 - 2020-09-18
+
 ### Added
+
 - Added new rules introduced in the last version.
   - Layout/BeginEndAlignment (0.91)
   - Lint/ConstantDefinitionInBlock (0.91)
@@ -343,11 +429,13 @@ The following rules have been added:
   - Rails/WhereNot (2.8)
 
 ### Changed
+
 - Updated all the extensions.
 
 ## 0.8.0 - 2020-08-07
 
 ### Added
+
 - Added new rules introduced in the last version.
   - Lint/BinaryOperatorWithIdenticalOperands (0.89)
   - Lint/DuplicateRescueException (0.89)
@@ -367,14 +455,17 @@ The following rules have been added:
 ## 0.7.0 - 2020-08-03
 
 ### Added
+
 - Added rubocop-faker as new extension
 
 ### Changed
+
 - Updated all the extensions, and configured new rules
 
 ## 0.6.0 - 2020-07-13
 
 ### Added
+
 - Added new rules introduced in the last version.
   - Lint/DeprecatedOpenSSLConstant (0.84)
   - Lint/MixedRegexpCaptureTypes (0.85)
@@ -396,22 +487,26 @@ The following rules have been added:
 ## 0.5.0 - 2020-07-07
 
 ### Changed
+
 - Actualizadas reglas
 
 ## 0.4.0 - 2020-02-26
 
 ### Changed
+
 - Remove Style/BracesAroundHashParameters cop
 
 ## 0.3.0 - 2020-02-07
 
 ### Changed
+
 - Set enforced style to braces_for_chaining in Style/BlockDelimiters cop.
 - Relax required versions of rubocop gems.
 
 ## 0.2.0 - 2019-12-23
 
 ### Changed
+
 - Move LineLength cop from Metrics to Layout and require rubocop 0.78.0.
 
 ## [0.1.0] - 2019-12-03

--- a/rubocop-bundler.yml
+++ b/rubocop-bundler.yml
@@ -1,3 +1,7 @@
 #
 ## https://rubocop.readthedocs.io/en/latest/cops_bundler/
 #
+
+# https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerduplicatedgroup
+Bundler/DuplicatedGroup:
+  Enabled: true

--- a/rubocop-capybara.yml
+++ b/rubocop-capybara.yml
@@ -24,3 +24,15 @@ Capybara/SpecificActions:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaramatchstyle
 Capybara/MatchStyle:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-capybara/cops_capybara_rspec.html#capybararspecpredicatematcher
+Capybara/RSpec/PredicateMatcher:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-capybara/cops_capybara_rspec.html#capybararspechaveselector
+Capybara/RSpec/HaveSelector:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: true

--- a/rubocop-default.yml
+++ b/rubocop-default.yml
@@ -2,6 +2,7 @@ inherit_from:
   - rubocop-all.yml
   - rubocop-bundler.yml
   - rubocop-capybara.yml
+  - rubocop-factory-bot.yml
   - rubocop-faker.yml
   - rubocop-gemspec.yml
   - rubocop-layout.yml

--- a/rubocop-factory-bot.yml
+++ b/rubocop-factory-bot.yml
@@ -1,0 +1,34 @@
+#
+## https://www.rubydoc.info/gems/rubocop-factory_bot/
+#
+
+require: rubocop-factory_bot
+
+# https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html#factorybotsyntaxmethods
+FactoryBot/SyntaxMethods:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotconsistentparenthesesstyle
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotfactorynamestyle
+FactoryBot/FactoryNameStyle:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html#factorybotassociationstyle
+FactoryBot/AssociationStyle:
+  Enabled: true
+  EnforcedStyle: explicit
+
+# https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html#factorybotfactoryassociationwithstrategy
+FactoryBot/FactoryAssociationWithStrategy:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html#factorybotidsequence
+FactoryBot/IdSequence:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-factory_bot/cops_factorybot.html#factorybotredundantfactoryoption
+FactoryBot/RedundantFactoryOption:
+  Enabled: true

--- a/rubocop-lint.yml
+++ b/rubocop-lint.yml
@@ -123,3 +123,15 @@ Lint/DuplicateMagicComment:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessrescue
 Lint/UselessRescue:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicatematchpattern
+Lint/DuplicateMatchPattern:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintmixedcaserange
+Lint/MixedCaseRange:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantregexpquantifiers
+Lint/RedundantRegexpQuantifiers:
+  Enabled: true

--- a/rubocop-nosolosoftware.gemspec
+++ b/rubocop-nosolosoftware.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   ## INFORMATION
   #
   s.name = 'rubocop-nosolosoftware'
-  s.version = '1.17.0'
+  s.version = '1.18.0'
   s.summary = 'Default Rubocop configuration used in NoSoloSoftware developments'
   s.description = nil
   s.homepage = 'https://github.com/nosolosoftware/rubocop-nosolosoftware'
@@ -47,11 +47,12 @@ Gem::Specification.new do |s|
   #
   ## DEPENDENCIES
   #
-  s.add_dependency 'rubocop', '~> 1.48.1'
-  s.add_dependency 'rubocop-capybara', '~> 2.17.1'
+  s.add_dependency 'rubocop', '~> 1.57.1'
+  s.add_dependency 'rubocop-capybara', '~> 2.19.0'
+  s.add_dependency 'rubocop-factory_bot', '~> 2.24.0'
   s.add_dependency 'rubocop-faker', '~> 1.1.0'
-  s.add_dependency 'rubocop-performance', '~> 1.16.0'
-  s.add_dependency 'rubocop-rails', '~> 2.18.0'
+  s.add_dependency 'rubocop-performance', '~> 1.19.1'
+  s.add_dependency 'rubocop-rails', '~> 2.21.2'
   s.add_dependency 'rubocop-rake', '~> 0.6.0'
-  s.add_dependency 'rubocop-rspec', '~> 2.19.0'
+  s.add_dependency 'rubocop-rspec', '~> 2.24.1'
 end

--- a/rubocop-performance.yml
+++ b/rubocop-performance.yml
@@ -79,3 +79,7 @@ Performance/StringIdentifierArgument:
 # https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceconcurrentmonotonictime
 Performance/ConcurrentMonotonicTime:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancemapmethodchain
+Performance/MapMethodChain:
+  Enabled: true

--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -269,3 +269,23 @@ Rails/IgnoredColumnsAssignment:
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsresponseparsedbody
 Rails/ResponseParsedBody:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsthreestatebooleancolumn
+Rails/ThreeStateBooleanColumn:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsselectmap
+Rails/SelectMap:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdangerouscolumnnames
+Rails/DangerousColumnNames:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedrendercontent
+Rails/UnusedRenderContent:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantactiverecordallmethod
+Rails/RedundantActiveRecordAllMethod:
+  Enabled: true

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -62,10 +62,6 @@ RSpec/ExcessiveDocstringSpacing:
 RSpec/SubjectDeclaration:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotsyntaxmethods
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: true
-
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbeeq
 RSpec/BeEq:
   Enabled: true
@@ -94,11 +90,6 @@ RSpec/NoExpectationExample:
 RSpec/ClassCheck:
   Enabled: true
 
-# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotconsistentparenthesesstyle
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: true
-  EnforcedStyle: "require_parentheses"
-
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsinferredspectype
 RSpec/Rails/InferredSpecType:
   Enabled: false
@@ -106,10 +97,6 @@ RSpec/Rails/InferredSpecType:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecsortmetadata
 RSpec/SortMetadata:
   Enabled: false
-
-# https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotfactorynamestyle
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: true
 
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecduplicatedmetadata
 RSpec/DuplicatedMetadata:
@@ -141,4 +128,41 @@ RSpec/MatchArray:
 
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecskipblockinsideexample
 RSpec/SkipBlockInsideExample:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecindexedlet
+RSpec/IndexedLet:
+  Enabled: true
+  Max: 3
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbeempty
+RSpec/BeEmpty:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsnegationbevalid
+RSpec/Rails/NegationBeValid:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecreceivemessages
+RSpec/ReceiveMessages:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecemptymetadata
+RSpec/EmptyMetadata:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspeceq
+RSpec/Eq:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmetadatastyle
+RSpec/MetadataStyle:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecspecfilepathformat
+RSpec/SpecFilePathFormat:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecspecfilepathsuffix
+RSpec/SpecFilePathSuffix:
   Enabled: true

--- a/rubocop-style.yml
+++ b/rubocop-style.yml
@@ -225,3 +225,47 @@ Style/DirEmpty:
 # https://docs.rubocop.org/rubocop/cops_style.html#stylefileempty
 Style/FileEmpty:
   Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantlinecontinuation
+Style/RedundantLineContinuation:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styledatainheritance
+Style/DataInheritance:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleexactregexpmatch
+Style/ExactRegexpMatch:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantarrayconstructor
+Style/RedundantArrayConstructor:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpconstructor
+Style/RedundantRegexpConstructor:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantfilterchain
+Style/RedundantFilterChain:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantcurrentdirectoryinpath
+Style/RedundantCurrentDirectoryInPath:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpargument
+Style/RedundantRegexpArgument:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylereturnnilinpredicatemethoddefinition
+Style/ReturnNilInPredicateMethodDefinition:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#styleyamlfileread
+Style/YAMLFileRead:
+  Enabled: true
+
+# https://docs.rubocop.org/rubocop/cops_style.html#stylesinglelinedoendblock
+Style/SingleLineDoEndBlock:
+  Enabled: true


### PR DESCRIPTION
# Feature/add new rules v1.18.0

- New gems:
   - rubocop-factory_bot: 2.24.0
   
- Update gems:

   - rubocop: 1.48.1 => 1.57.1
   - rubocop-capybara: 2.17.1 => 2.19.0
   - rubocop-performance: 1.16.0 => 1.19.1
   - rubocop-rails: 2.18.0 => 2.21.2
   - rubocop-rspec: 2.21.2 => 2.24.1
   
 - Added new rules
 
    - rubocop
   
      - Style/RedundantLineContinuation (1.49.0)
      - Style/DataInheritance (1.49.0)
      - Lint/DuplicateMatchPattern (1.50.0)
      - Style/ExactRegexpMatch (1.51.0)
      - Style/RedundantArrayConstructor (1.52.0)
      - Style/RedundantRegexpConstructor (1.52.0)
      - Style/RedundantFilterChain (1.52.0)
      - Lint/MixedCaseRange (1.53.0)
      - Lint/RedundantRegexpQuantifiers (1.53.0)
      - Style/RedundantCurrentDirectoryInPath (1.53.0)
      - Style/ReturnNilInPredicateMethodDefinition (1.53.0)
      - Style/YAMLFileRead (1.53.0)
      - Bundler/DuplicatedGroup (1.56.0)
      - Style/SingleLineDoEndBlock (1.57.0)
      
    - rubocop-capybara
    
      - Capybara/RSpec/PredicateMatcher (2.19.0)
      - Capybara/RSpec/HaveSelector (2.19.0)
      - Capybara/ClickLinkOrButtonStyle (2.19.0)
      
    - rubocop-performance
    
      - Performance/MapMethodChain (1.19.0)
      
    - rubocop-rails
    
      - Rails/ThreeStateBooleanColumn (2.19.0)
      - Rails/SelectMap (2.21.0)
      - Rails/DangerousColumnNames (2.21.0)
      - Rails/UnusedRenderContent (2.21.0)
      - Rails/RedundantActiveRecordAllMethod (2.21.0)
      
    - rubocop-rspec
    
      - RSpec/IndexedLet (2.20.0)
      - RSpec/BeEmpty (2.20.0)
      - RSpec/Rails/NegationBeValid (2.23.0)
      - RSpec/ReceiveMessages (2.23.0)
      - RSpec/EmptyMetadata (2.24.0)
      - RSpec/Eq (2.24.0)
      - RSpec/MetadataStyle (2.24.0)
      - RSpec/SpecFilePathFormat (2.24.0)
      - RSpec/SpecFilePathSuffix (2.24.0)
      
    - rubocop-factory_bot
    
      - FactoryBot/AssociationStyle (2.23.0)
      - FactoryBot/FactoryAssociationWithStrategy (2.23.0)
      - FactoryBot/IdSequence (2.23.0)
      - FactoryBot/RedundantFactoryOption (2.23.0)